### PR TITLE
Fixed parse error when spaces occur in json log files

### DIFF
--- a/deltalake/deltatable.py
+++ b/deltalake/deltatable.py
@@ -93,7 +93,7 @@ class DeltaTable:
 
             # Download log file
             log = self.filesystem.cat(log_file)
-            for line in log.split():
+            for line in log.splitlines():
                 meta_data = json.loads(line)
                 # Log contains other stuff, but we are only
                 # interested in the add or remove entries


### PR DESCRIPTION
This solves the following issue: [Predicates in json log files can contain spaces and breaks the parsing](https://github.com/jeppe742/DeltaLakeReader/issues/6)