### PR TITLE
allow schema w DECIMAL types where 2nd arg >9

### DIFF
--- a/deltalake/schema.py
+++ b/deltalake/schema.py
@@ -44,7 +44,7 @@ def map_type(input_type: Union[dict, str]):
             pa_type = simple_type_mapping[input_type]
         else:
             # check for decimal types
-            match = re.findall(r"decimal\(([0-9]*),([0-9])\)", input_type)
+            match = re.findall(r"decimal\(([0-9]*),([0-9]*)\)", input_type)
             if len(match) > 0:
                 pa_type = pa.decimal128(int(match[0][0]), int(match[0][1]))
             else:


### PR DESCRIPTION
Prior to this change, I got the following error:
```
TypeError: Got type unsupported decimal(38,18) when trying to parse schema
```

The change seems to resolve the issue.