### PR TITLE
Change to detect if Delta Lake format with _last_checkpoint file

### DIFF
--- a/deltalake/deltatable.py
+++ b/deltalake/deltatable.py
@@ -53,7 +53,7 @@ class DeltaTable:
         )
 
     def _is_delta_table(self):
-        return self.filesystem.exists(f"{self.log_path}/{0:020}.json")
+        return self.filesystem.exists(f"{self.log_path}/_last_checkpoint")
 
     def _reset_state(self):
         self.files = set()


### PR DESCRIPTION
With vacuum function or create subsequence versions, `_delta_log/00000000000000000000.json` can be deleted and `_is_delta_table` will fail to check if is a Delta Lake format. I changed to `_last_checkpoint` because this file will not be deleted by the future versions of the table.