### PR TITLE
update_metadata_values_to_string

### DIFF
--- a/deltalake/schema.py
+++ b/deltalake/schema.py
@@ -4,18 +4,15 @@ from typing import Union
 
 import pyarrow as pa
 
-
 def schema_from_string(schema_string: str):
-
     fields = []
     schema = json.loads(schema_string)
     for field in schema["fields"]:
         name = field["name"]
         type = field["type"]
         nullable = field["nullable"]
-        metadata = field["metadata"]
+        metadata = {key: str(value) for key, value in field["metadata"].items()}
         pa_type = map_type(type)
-
         fields.append(pa.field(name, pa_type, nullable=nullable, metadata=metadata))
     return pa.schema(fields)
 


### PR DESCRIPTION
Delta Lake now has column mapping features that lets you rename a column. This change is only reflected in the and enables metadata only changes. The read and writer version are saved as integers and should be converted to strings. The function simply converts all of the values in the metadata dictionary into string values to avoid the error.