### PR TITLE
Update deltatable.py_Error Handling added to _apply_partial_logs function

### DIFF
--- a/deltalake/deltatable.py
+++ b/deltalake/deltatable.py
@@ -126,8 +126,11 @@ class DeltaTable:
                         if remove_file in self.files:
                             self.files.remove(remove_file)
                     elif "metaData" in meta_data.keys():
-                        schema_string = meta_data["metaData"]["schemaString"]
-                        self.schema = schema_from_string(schema_string)
+                        try:
+                           schema_string = meta_data["metaData"]["schemaString"]
+                           self.schema = schema_from_string(schema_string)
+                        except KeyError as e:
+                            print(f"problematic record : {log_file},{e}")
                 # Stop if we have reatched the desired version
                 if self.version == version:
                     break


### PR DESCRIPTION
Error Handling added to _apply_partial_logs function to handle schemaString error due to imperfection in delta logs.

While I am trying to load my delta table, I am facing key error. This error occured due to imperfections in delta logs as it can not find schemaString in one of the checkpoint in my delta logs. Due to this error DeltaTable is not able to load records. Using this error handling I am able to skip the problematic record and able to load the new records.
![IMG_20240309_031808](https://github.com/jeppe742/DeltaLakeReader/assets/49644695/3b798401-214a-4158-8bf4-35d4ff4eb531)
